### PR TITLE
Locks event-stream to 3.3.4

### DIFF
--- a/node-data-tools/package.json
+++ b/node-data-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidepool/data-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Export data from the Tidepool API to various file formats",
   "repository": "https://github.com/tidepool-org/data-analytics.git",
   "author": "Lennart Goedhart <lennart@tidepool.org>",
@@ -19,7 +19,7 @@
     "commander": "2.19.0",
     "csv-string": "3.1.5",
     "esm": "3.0.84",
-    "event-stream": "4.0.1",
+    "event-stream": "=3.3.4",
     "exceljs": "1.6.2",
     "flat": "4.1.0",
     "lodash": "4.17.11",


### PR DESCRIPTION
Versions >3.3.4 contained a security vulnerability.
See https://github.com/dominictarr/event-stream/issues/116